### PR TITLE
hellwal: Added flake/hm-module/dev-shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733759999,
+        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "A flake with hellwal package/hm-module/dev-shell";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+      let
+        system = "x86_64-linux";
+        inherit (nixpkgs) lib;
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages."x86_64-linux".default = pkgs.callPackage ./nix/default.nix {};
+        
+        homeManagerModules.default = import ./nix/hm-module.nix;
+
+        devShells."x86_64-linux".default = pkgs.mkShell {
+          nativeBuildInputs = [
+            self.packages.x86_64-linux.default
+          ];
+        };
+      };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,42 @@
+
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hellwal";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "danihek";
+    repo = "hellwal";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TrqXInoz6OEtS12YmXUILV41IkZW0B4XAAESiU2yMMU=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -Dm755 hellwal -t $out/bin
+    mkdir -p $out/share/docs/hellwal
+    cp -r templates themes $out/share/docs/hellwal
+  '';
+
+  meta = {
+    homepage = "https://github.com/danihek/hellwal";
+    description = "Fast, extensible color palette generator";
+    longDescription = ''
+      Pywal-like color palette generator, but faster and in C.
+    '';
+    license = lib.licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
+    maintainers = with lib.maintainers; [ danihek ];
+    mainProgram = "hellwal";
+  };
+})

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,12 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "hellwal";
   version = "1.0.2";
 
-  src = fetchFromGitHub {
-    owner = "danihek";
-    repo = "hellwal";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-TrqXInoz6OEtS12YmXUILV41IkZW0B4XAAESiU2yMMU=";
-  };
+  src = ../.;
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,81 @@
+{ pkgs, config, lib, ... }:
+
+with lib;
+
+let cfg = config.programs.hellwal;
+hellwal= pkgs.callPackage ./default.nix {};
+in {
+  options = { programs.hellwal = { enable = mkEnableOption "hellwal"; }; };
+
+  config = mkIf cfg.enable {
+
+    home.packages = [ hellwal ];
+    
+    programs.zsh.initExtra = ''
+      # Import colorscheme from 'hellwal' asynchronously
+      # &   # Run the process in the background.
+      # ( ) # Hide shell job control messages.
+      (cat ${config.xdg.cacheHome}/hellwal/sequences &)
+    '';
+
+    #kitty configuration
+    programs.kitty.extraConfig = ''
+      include ${config.xdg.cacheHome}/hellwal/colors-kitty.conf
+    '';
+
+    programs.rofi.theme."@import" =
+      "${config.xdg.cacheHome}/hellwal/colors-rofi-dark.rasi";
+
+    # programs.neovim.plugins = [{
+    #   plugin = pkgs.vimPlugins.pywal-nvim;
+    #   type = "lua";
+    # }];
+
+    # wal generates and that's the one we should load from /home/teto/.cache/wal/colors.Xresources ~/.Xresources
+    # xsession.windowManager.i3 = {
+    #   extraConfig = ''
+    #     set_from_resource $bg           i3wm.color0 #ff0000
+    #     set_from_resource $bg-alt       i3wm.color14 #ff0000
+    #     set_from_resource $fg           i3wm.color15 #ff0000
+    #     set_from_resource $fg-alt       i3wm.color2 #ff0000
+    #     set_from_resource $hl           i3wm.color13 #ff0000
+    #   '';
+
+    #   config.colors = {
+    #     focused = {
+    #       border = "$fg-alt";
+    #       background = "$bg";
+    #       text = "$hl";
+    #       indicator = "$fg-alt";
+    #       childBorder = "$hl";
+    #     };
+
+    #     focusedInactive = {
+    #       border = "$fg-alt";
+    #       background = "$bg";
+    #       text = "$fg";
+    #       indicator = "$fg-alt";
+    #       childBorder = "$fg-alt";
+    #     };
+
+    #     unfocused = {
+    #       border = "$fg-alt";
+    #       background = "$bg";
+    #       text = "$fg";
+    #       indicator = "$fg-alt";
+    #       childBorder = "$fg-alt";
+    #     };
+
+    #     urgent = {
+    #       border = "$fg-alt";
+    #       background = "$bg";
+    #       text = "$fg";
+    #       indicator = "$fg-alt";
+    #       childBorder = "$fg-alt";
+    #     };
+
+    #     background = "$bg";
+    #   };
+    # };
+  };
+}


### PR DESCRIPTION
I really liked the concept of hellwal. I created a flake.nix for myself (referencing your pr to nixpkgs) to use it before its release to nixos officially. Also added a hm-module similar to [pywal hm-module ](https://home-manager-options.extranix.com/?query=pywal&release=master).  Yet the module is merely a copy of pywal's module. Maybe you can tweak it yourself for better use cases :)

Maybe you can merge this to your official repo for anyone to use the latest build directly. 

(Also I don't know the internals of your program but if you could have a branch where the binary name is changed to wal instead with matching command line options to pywal (something similar to [pywal16](https://search.nixos.org/packages?channel=24.11&from=0&size=50&sort=relevance&type=packages&query=pywal16) ). An option can be added to hm module like pywal-integration.enable to be directly able to make use of already existing pywal services like wpgtk/pywalfox  etc... Or maybe a better alternative to that?) 