### PR TITLE
Fix: Memory Warning and Math Library Issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ LDFLAGS = -lm
 DESTDIR = /usr/local/bin
 
 hellwal: hellwal.c
-	$(CC) $(CFLAGS) $(LDFLAGS) hellwal.c -o hellwal
+	$(CC) $(CFLAGS) hellwal.c -o hellwal $(LDFLAGS)
 
 debug: hellwal.c
-	$(CC) $(CFLAGS) -ggdb $(LDFLAGS) hellwal.c -o hellwal
+	$(CC) $(CFLAGS) -ggdb hellwal.c -o hellwal $(LDFLAGS)
 
 clean:
 	rm hellwal

--- a/hellwal.c
+++ b/hellwal.c
@@ -2106,8 +2106,6 @@ int process_theme(char *t, PALETTE *pal)
 
     if (processed_colors == PALETTE_SIZE)
         return 1;
-    if (processed_colors > 0)
-        free(pal);
 
     return 0;
 }


### PR DESCRIPTION
Fixes two problems:

1. Removes warning about freeing memory incorrectly in hellwal.c
   - Removed a line that was trying to free memory it shouldn't
   - Warning message "free called on unallocated object" is now gone

2. Fixes math functions not working in the program
   - Updated Makefile to properly link math functions
   - Functions like pow(), fmaxf(), and fminf() now work correctly

Changes made:
- hellwal.c: Removed problematic free(pal) line
- Makefile: Fixed the order of compiler flags

Testing:
- Program now compiles without warnings
- All math functions work properly