### PR TITLE
add basic rofi template

### DIFF
--- a/templates/rofi.rasi
+++ b/templates/rofi.rasi
@@ -1,0 +1,167 @@
+* {
+    active-background: #%% color2.hex %%;
+    active-foreground: #%% foreground.hex %%;
+    normal-background: #%% background.hex %%;
+    normal-foreground: #%% foreground.hex %%;
+    urgent-background: #%% color1.hex %%;
+    urgent-foreground: #%% foreground.hex %%;
+
+    alternate-active-background: #%% background.hex %%;
+    alternate-active-foreground: #%% foreground.hex %%;
+    alternate-normal-background: #%% background.hex %%;
+    alternate-normal-foreground: #%% foreground.hex %%;
+    alternate-urgent-background: #%% background.hex %%;
+    alternate-urgent-foreground: #%% foreground.hex %%;
+
+    selected-active-background: #%% color1.hex %%;
+    selected-active-foreground: #%% foreground.hex %%;
+    selected-normal-background: #%% color2.hex %%;
+    selected-normal-foreground: #%% foreground.hex %%;
+    selected-urgent-background: #%% color3.hex %%;
+    selected-urgent-foreground: #%% foreground.hex %%;
+
+    background-color: #%% background.hex %%;
+    background: #%% background.hex %%;
+    foreground: #%% foreground.hex %%;
+    border-color: @active-background;
+    spacing: 2;
+}
+
+window {
+    background-color: @background;
+    border-color: @active-background;
+    border: 3;
+    padding: 2.5ch;
+}
+
+mainbox {
+    border: 0;
+    padding: 0;
+}
+
+message {
+    border: 2px 0px 0px;
+    border-color: @border-color;
+    padding: 1px;
+}
+
+textbox {
+    text-color: @foreground;
+}
+
+inputbar {
+    children:   [ prompt,textbox-prompt-colon,entry,case-indicator ];
+}
+
+textbox-prompt-colon {
+    expand: false;
+    str: ":";
+    margin: 0px 0.3em 0em 0em;
+    text-color: @normal-foreground;
+}
+
+listview {
+    fixed-height: 0;
+    border: 2px 0px 0px;
+    border-color: @border-color;
+    spacing: 2px;
+    scrollbar: true;
+    padding: 2px 0px 0px;
+}
+
+element {
+    order: 0;
+    padding: 1px;
+}
+
+element-text, element-icon {
+    background-color: inherit;
+    text-color:       inherit;
+}
+
+element.normal.normal {
+    background-color: @normal-background;
+    text-color: @normal-foreground;
+}
+
+element.normal.urgent {
+    background-color: @urgent-background;
+    text-color: @urgent-foreground;
+}
+
+element.normal.active {
+    background-color: @active-background;
+    text-color: @active-foreground;
+}
+
+element.selected.normal {
+    background-color: @selected-normal-background;
+    text-color: @selected-normal-foreground;
+}
+
+element.selected.urgent {
+    background-color: @selected-urgent-background;
+    text-color: @selected-urgent-foreground;
+}
+
+element.selected.active {
+    background-color: @selected-active-background;
+    text-color: @selected-active-foreground;
+}
+
+element.alternate.normal {
+    background-color: @alternate-normal-background;
+    text-color: @alternate-normal-foreground;
+}
+
+element.alternate.urgent {
+    background-color: @alternate-urgent-background;
+    text-color: @alternate-urgent-foreground;
+}
+
+element.alternate.active {
+    background-color: @alternate-active-background;
+    text-color: @alternate-active-foreground;
+}
+
+scrollbar {
+    width: 4px;
+    border: 0;
+    handle-width: 8px;
+    padding: 0;
+}
+
+sidebar {
+    border: 2px 0px 0px;
+    border-color: @border-color;
+}
+
+button {
+    text-color: @normal-foreground;
+}
+
+button.selected {
+    background-color: @selected-normal-background;
+    text-color: @selected-normal-foreground;
+}
+
+inputbar {
+    spacing: 0;
+    text-color: @normal-foreground;
+    padding: 1px;
+}
+
+case-indicator {
+    spacing: 0;
+    text-color: @normal-foreground;
+}
+
+entry {
+    spacing: 0;
+    text-color: @normal-foreground;
+}
+
+prompt {
+    spacing: 0;
+    text-color: @normal-foreground;
+}


### PR DESCRIPTION
Adds a basic rofi template. This is based on [the template in pywal](https://github.com/dylanaraps/pywal/blob/master/pywal/templates/colors-rofi-dark.rasi), but updated to work with the latest rofi release (1.7.8)


https://github.com/user-attachments/assets/6180c2b8-4e83-4e50-8907-61576cab5a92

