### PR TITLE
Add handling for single delim characters

### DIFF
--- a/hellwal.c
+++ b/hellwal.c
@@ -1871,6 +1871,26 @@ void process_template(TEMPLATE *t, PALETTE pal)
                 }
                 else
                 {
+		    int is_double_delim = 0;
+		    if (p->pos < p->length && p->input[p->pos] == HELLWAL_DELIM)
+                    {
+                        is_double_delim = 1;
+                    }
+                    
+                    if (!is_double_delim)
+                    {
+                        /* It's a single %, just add it to the buffer and continue */
+                        int size_before_delim = p->pos - buffrd_pos;
+                        if (size_before_delim > 0)
+                        {
+                            template_size += size_before_delim + 1;
+                            template_buffer = realloc(template_buffer, template_size);
+                            strncat(template_buffer, p->input + buffrd_pos, size_before_delim);
+                        }
+                        buffrd_pos = p->pos;
+                        continue;
+                    }
+
                     p->pos -= 1;
                     int idx = 0;
                     size_t len = 0;


### PR DESCRIPTION
This seems to work I've tested it on all the default templates and some of mine that were failing due to single `%` characters. I did try some templates with multiple repeating `%` characters, which does confuse the parsing but I get the same outcome on the current code and with these tweaks. However, I doubt many users would ever need to handle `%%%%color4.hex%%%%` or any other combination of `%` symbols.

The current issue is if the parser sees a template such as:
```css
.header {
    width: 100%;
    height: 60px;
    background-color: %%background.hex%%;
    border-bottom: 2px solid %%color1.hex%%;
}
```
The parser would output this:
```css
.header {
    width: 1000a1c26;
    border-bottom: 2px solid 5697d4;
}
```
With the changes you get:
```css
.header {
    width: 100%;
    height: 60px;
    background-color: 0a1c26;
    border-bottom: 2px solid 5697d4;
}
```
