### PR TITLE
Add a template option to get a single RGB channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ color15butRGB='%%color15.rgb%%'
 
 You can get any generated color for values 0 to 15.
 
-After the color keyword, you can specify the format: hex or rgb. By default, the template output
-is in hex.
+After the color keyword, you can specify the format: hex, rgb, or a single rgb channel.
+By default, the template output is in hex.
 
 ### Available color template formats:
 
@@ -109,6 +109,9 @@ is in hex.
 | ---- | ---------- | ------- |
 | hex  | color0.hex | 000000  |
 | rgb  | color0.rgb | 0, 0, 0 |
+| r    | color0.r   | 0       |
+| g    | color0.g   | 0       |
+| b    | color0.b   | 0       |
 
 ### Additional variables accepted by templates
 
@@ -118,6 +121,8 @@ For now these variables are available:
 | Variable | Description            | Usage                        |
 | -------- | ---------------------- | ---------------------------- |
 | alpha    | Set transparency value | `%% color1.hex alpha=0.5 %%` |
+
+`alpha` is ignored for single rgb channels.
 
 ## JSON
 

--- a/hellwal.c
+++ b/hellwal.c
@@ -2090,7 +2090,7 @@ void process_template(TEMPLATE *t, PALETTE pal)
                             remove_whitespaces(right);
 
                             idx = is_color_palette_var(left);
-                            if (idx != -1 && pd->pos + 1 < pd->length)
+                            if (idx != -1 && pd->pos < pd->length)
                             {
                                 /* 
                                  * check if after '.' is rgb, if yes get output as rgb,

--- a/hellwal.c
+++ b/hellwal.c
@@ -409,6 +409,7 @@ void check_palette_contrast(PALETTE *palette);
 char *load_file(char *filename);
 void process_templating(PALETTE pal);
 size_t template_write(TEMPLATE *t, char *dir);
+enum COLOR_TYPES parse_color_type(const char *str);
 void process_template(TEMPLATE *t, PALETTE pal);
 TEMPLATE **get_template_structure_dir(const char *dir_path, size_t *_size);
 
@@ -1880,6 +1881,14 @@ void process_templating(PALETTE pal)
     log_c("Processed [%d/%d] templates!", t_success, templates_count);
 }
 
+enum COLOR_TYPES parse_color_type(const char *str)
+{
+    if (!strcmp(str, "rgb"))
+        return RGB_t;
+
+    return HEX_t;
+}
+
 /* load t->path file to buffer and replaces content between delim with colors from PALETTE colors */
 void process_template(TEMPLATE *t, PALETTE pal)
 {
@@ -2087,33 +2096,18 @@ void process_template(TEMPLATE *t, PALETTE pal)
                                  * check if after '.' is rgb, if yes get output as rgb,
                                  * if not output will always be hex
                                  */
-                                if (!strcmp(right, "rgb"))
-                                {
-                                    var_arg = palette_color(pal, idx, RGB_t);
-                                    type = RGB_t;
-                                }
-                                else
-                                    var_arg = palette_color(pal, idx, HEX_t);
+                                type = parse_color_type(right);
+                                var_arg = palette_color(pal, idx, type);
                             }
                             else if (!strcmp(left, "foreground") || !strcmp(left, "cursor") || !strcmp(left, "border"))
                             {
-                                if (!strcmp(right, "rgb"))
-                                {
-                                    var_arg = palette_color(pal, PALETTE_SIZE - 1, RGB_t);
-                                    type = RGB_t;
-                                }
-                                else
-                                    var_arg = palette_color(pal, PALETTE_SIZE - 1, HEX_t);
+                                type = parse_color_type(right);
+                                var_arg = palette_color(pal, PALETTE_SIZE - 1, type);
                             }
                             else if (!strcmp(left, "background"))
                             {
-                                if (!strcmp(right, "rgb"))
-                                {
-                                    var_arg = palette_color(pal, 0, RGB_t);
-                                    type = RGB_t;
-                                }
-                                else
-                                    var_arg = palette_color(pal, 0, HEX_t);
+                                type = parse_color_type(right);
+                                var_arg = palette_color(pal, 0, type);
                             }
 
                             free(left);


### PR DESCRIPTION
Adds a way to get a single red, green, or blue channel in templates, and closes #25.

I also fixed a string length comparison that had required more than 1 letter after the `.`. It didn't have any effect for keywords like `hex` or `rgb`, but matters for the new single letter keywords `r`, `g`, and `b`.