### PR TITLE
Improved and tweaked script/template documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Then add this to your fish config:
 
 ```sh
 source ~/.cache/hellwal/variablesfish.fish
-fish ~/.cache/hellwal/terminal.sh
+sh ~/.cache/hellwal/terminal.sh
 ```
 
 # Showcase

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ add these templates to your `~/.config/hellwal/templates/` folder:
 - [variables.sh](./templates/variables.sh)
 - [terminal.sh](./templates/terminal.sh)
 
+Run hellwal with an image or theme to generate the output scripts from the templates.
+
 Then in `.bashrc`, add following lines:
 
 ```sh


### PR DESCRIPTION
1. Made a minor change to use `sh` for execution of `terminal.sh` instead of `fish` for the fish implementation. 
    - Using fish without blocking execution via `status is-interactive` or other means results in the terminal halting from recursive execution of the fish config.

2. Added a small section to clarify that hellwal needs to be run after importing the templates to generate the output scripts.